### PR TITLE
Made it easier for people to add context navigation within a module, even with nested nodes

### DIFF
--- a/hydeengine/siteinfo.py
+++ b/hydeengine/siteinfo.py
@@ -350,6 +350,8 @@ class ContentNode(SiteNode):
             self.listing_page = page
         self.resources.append(page)
         page.node.sort()
+        if not page.module == self.site:
+            page.module.flatten_and_sort()
         return page
 
     def sort(self):
@@ -366,6 +368,21 @@ class ContentNode(SiteNode):
                 prev = page
         for node in self.children:
             node.sort()
+
+    def flatten_and_sort(self):
+        flattened_pages = []
+        prev_in_module = None
+        for page in self.walk_pages():
+            flattened_pages.append(page)
+        flattened_pages.sort(key=operator.attrgetter("created"), reverse=True)
+        for page in flattened_pages:
+            page.next_in_module = None
+            if page.display_in_list:
+                if prev_in_module:
+                    prev_in_module.next_in_module = page
+                    page.prev_in_module = prev_in_module
+                page.next_in_module = None
+                prev_in_module = page
 
     @property
     def target_folder(self):


### PR DESCRIPTION
Hello,

I recently had the problem where I needed to get the next article in my blog for context navigation, but it was in a different node within the same module. For details on this problem, see [this issue](https://github.com/lakshmivyas/hyde/issues/issue/39).

I've added support for the template tags `next_in_module` and `prev_in_module` for the `page` object, so that if you want to get the next page in the same node, you can use `page.next`, but if you want to get the next page in the same module, regardless of node, you can use `page.next_in_module`.

I found this template tag useful in my blog, so I hope this will be of use to other users too.

Please let me know if you have any questions.

Thanks,
Chetan
