### PR TITLE
use traceback.print_exc so you can actually see what the exception was and where it happened

### DIFF
--- a/hydeengine/__init__.py
+++ b/hydeengine/__init__.py
@@ -7,6 +7,7 @@ import mimetypes
 import os
 import sys
 import subprocess
+import traceback
 import urllib
 
 from collections import defaultdict
@@ -417,7 +418,7 @@ class Generator(object):
             self.complete_generation()
         except Exception, e:
             print >> sys.stderr, "Generation Failed"
-            print >> sys.stderr, sys.exc_info()
+            traceback.print_exc(file=sys.stderr)
             self.notify(self.siteinfo.name, "Generation Failed")
             return
         self.notify(self.siteinfo.name, "Generation Complete")
@@ -458,7 +459,7 @@ class Generator(object):
                     self.regenerate_request.clear()
             except:
                 print >> sys.stderr, "Error during regeneration"
-                print >> sys.stderr, sys.exc_info()
+                traceback.print_exc(file=sys.stderr)
                 self.notify(self.siteinfo.name, "Error during regeneration")
                 self.regeneration_complete.set()
                 self.regenerate_request.clear()
@@ -507,7 +508,7 @@ class Generator(object):
                     self.notify(self.siteinfo.name, "Completed processing " + resource.name)
             except:
                 print >> sys.stderr, "Error during regeneration"
-                print >> sys.stderr, sys.exc_info()
+                traceback.print_exc(file=sys.stderr)
                 self.notify(self.siteinfo.name, "Error during regeneration")
                 self.regeneration_complete.set()
                 self.regenerate_request.clear()

--- a/hydeengine/media_processors.py
+++ b/hydeengine/media_processors.py
@@ -58,6 +58,7 @@ class SASS:
             print output
             return None
         resource.source_file.delete()
+        resource.source_file = out_file
 
 class LessCSS:
     @staticmethod

--- a/hydeengine/media_processors.py
+++ b/hydeengine/media_processors.py
@@ -49,11 +49,12 @@ class SASS:
     @staticmethod
     def process(resource):
         out_file = File(resource.source_file.path_without_extension + ".css")
+        load_path = os.path.dirname(resource.file.path)
         sass = settings.SASS_PATH
         if not sass or not os.path.exists(sass):
             raise ValueError("SASS Processor cannot be found at [%s]" % sass)
         status, output = commands.getstatusoutput(
-        u"%s %s %s" % (sass, resource.source_file.path, out_file))
+        u"%s -I %s %s %s" % (sass, load_path, resource.source_file.path, out_file))
         if status > 0:
             print output
             return None


### PR DESCRIPTION
I had a crash happening and couldn't actually see where the error was, so I changed it up a smidge to print the traceback.

Also, I fixed the crash that was happening, which was due to the SASS media processor deleting the .sass file and then not pointing to the .css file instead.

Also, @include wasn't working properly for underscore-prefixed sass files because sass only looks in the same directory as the file it's processing, and the _-files are not copied into the temp dir.
