### PR TITLE
Add in a helper class for OrdedDicts

### DIFF
--- a/hydeengine/__init__.py
+++ b/hydeengine/__init__.py
@@ -24,6 +24,11 @@ from processor import Processor
 from siteinfo import SiteInfo
 from url import clean_url
 
+try:
+    from collections import OrderedDict
+except ImportError:
+    from _collections import OrderedDict
+
 class _HydeDefaults:
     GENERATE_CLEAN_URLS = False
     GENERATE_ABSOLUTE_FS_URLS = False
@@ -360,7 +365,7 @@ class Generator(object):
             try:
                 subprocess.call([settings.GROWL, "-n", "Hyde", "-t", title, "-m", message])
             except:
-                pass    
+                pass
         elif hasattr(settings, "NOTIFY") and settings.NOTIFY and File(settings.NOTIFY).exists:
             try:
                 subprocess.call([settings.NOTIFY, "Hyde: " + title, message])

--- a/hydeengine/_collections.py
+++ b/hydeengine/_collections.py
@@ -1,0 +1,100 @@
+from UserDict import DictMixin
+
+class OrderedDict(dict, DictMixin):
+
+    def __init__(self, *args, **kwds):
+        if len(args) > 1:
+            raise TypeError('expected at most 1 arguments, got %d' % len(args))
+        try:
+            self.__end
+        except AttributeError:
+            self.clear()
+        self.update(*args, **kwds)
+
+    def clear(self):
+        self.__end = end = []
+        end += [None, end, end]         # sentinel node for doubly linked list
+        self.__map = {}                 # key --> [key, prev, next]
+        dict.clear(self)
+
+    def __setitem__(self, key, value):
+        if key not in self:
+            end = self.__end
+            curr = end[1]
+            curr[2] = end[1] = self.__map[key] = [key, curr, end]
+        dict.__setitem__(self, key, value)
+
+    def __delitem__(self, key):
+        dict.__delitem__(self, key)
+        key, prev, next = self.__map.pop(key)
+        prev[2] = next
+        next[1] = prev
+
+    def __iter__(self):
+        end = self.__end
+        curr = end[2]
+        while curr is not end:
+            yield curr[0]
+            curr = curr[2]
+
+    def __reversed__(self):
+        end = self.__end
+        curr = end[1]
+        while curr is not end:
+            yield curr[0]
+            curr = curr[1]
+
+    def popitem(self, last=True):
+        if not self:
+            raise KeyError('dictionary is empty')
+        if last:
+            key = reversed(self).next()
+        else:
+            key = iter(self).next()
+        value = self.pop(key)
+        return key, value
+
+    def __reduce__(self):
+        items = [[k, self[k]] for k in self]
+        tmp = self.__map, self.__end
+        del self.__map, self.__end
+        inst_dict = vars(self).copy()
+        self.__map, self.__end = tmp
+        if inst_dict:
+            return (self.__class__, (items,), inst_dict)
+        return self.__class__, (items,)
+
+    def keys(self):
+        return list(self)
+
+    setdefault = DictMixin.setdefault
+    update = DictMixin.update
+    pop = DictMixin.pop
+    values = DictMixin.values
+    items = DictMixin.items
+    iterkeys = DictMixin.iterkeys
+    itervalues = DictMixin.itervalues
+    iteritems = DictMixin.iteritems
+
+    def __repr__(self):
+        if not self:
+            return '%s()' % (self.__class__.__name__,)
+        return '%s(%r)' % (self.__class__.__name__, self.items())
+
+    def copy(self):
+        return self.__class__(self)
+
+    @classmethod
+    def fromkeys(cls, iterable, value=None):
+        d = cls()
+        for key in iterable:
+            d[key] = value
+        return d
+
+    def __eq__(self, other):
+        if isinstance(other, OrderedDict):
+            return len(self)==len(other) and self.items() == other.items()
+        return dict.__eq__(self, other)
+
+    def __ne__(self, other):
+        return not self == other


### PR DESCRIPTION
I recently made 2 Site Post Processors, the issue is that one of them has to run before the other however there is no way of doing so within Hyde. I figured using an OrderedDict would be the best way of managing this.

OrdedDicts are new in python2.7 but there is an implementation for lesser python versions. This commit adds to **init**.py to first attempt to import OrderedDict from stdlib, and if that files, to import it from the second file this commit adds.

This allows usage in hyde settings by doing import hydeengine, then doing something like...

```
SITE_POST_PROCESSORS = {
    '/': hydeengine.OrderedDict([
            ('hyde_slimmer.site_post_processors.Compress', {
                'slimmer': {
                    '*.html': 'html',
                }
            }),
            ('zipper.site_post_processors.GzipCompress', {
                'filetypes': ['*html', '*.css', '*.js', '*.xml'],
                'level': 9,
            }),
        ])
}
```
